### PR TITLE
Apply fixes and add recursive_dict test

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ It works with many different types, with support for **Unions** and typed **List
 ```python
 data = [100, "string", 0.25, {"city": "Dallas", "state": "Texas"}]
 
-# The 100, "string", and 0.25 will be uneffected, while the 
+# The 100, "string", and 0.25 will be unaffected, while the 
 # location data will be converted to a Location object
 molded_data = mold_value(data, list[int | str | float | Location])
 ```

--- a/doms_json/__init__.py
+++ b/doms_json/__init__.py
@@ -412,7 +412,7 @@ def pull_docstring_parameters(obj) -> dict:
 # function(variable: str) -> {"title": "function", "type": "object", "properties": {"variable": {"type": "string"}}}
 def generate_json_schema(obj: FunctionType | type, additional_properties: bool = False, pull_descriptions: bool = True, pull_required: bool = True) -> dict | None:
     """
-    Convert a function or object into a JSON
+    Convert a function or object into a JSON Schema
     
     It can pull descriptions from docstrings using the reStructuredText (reST) format
 
@@ -500,7 +500,6 @@ def generate_json_schema(obj: FunctionType | type, additional_properties: bool =
             # If the variable isn't in the list of properties yet, append it
             if k not in properties:
                 properties.append(k)
-            properties.append(k)
         # If no properties were defined, then the object given is cannot be turned into a JSON Schema
         if len(properties) == 0:
             raise InvalidInput("A JSON Schema cannot be generated from the object given")

--- a/tests/test_recursive_dict.py
+++ b/tests/test_recursive_dict.py
@@ -1,0 +1,20 @@
+from doms_json import recursive_dict
+
+class Child:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+class Parent:
+    def __init__(self, child: Child, values: list[int]) -> None:
+        self.child = child
+        self.values = values
+
+
+def test_recursive_dict():
+    parent = Parent(Child("A"), [1, 2, 3])
+    result = recursive_dict(parent)
+    assert result == {
+        "child": {"name": "A"},
+        "values": [1, 2, 3]
+    }
+


### PR DESCRIPTION
## Summary
- fix README typo
- clarify generate_json_schema docstring
- prevent duplicate property entries when generating schemas
- test recursive_dict helper

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68409d6eb9d88320b9c42ca421d3f340