### PR TITLE
Add Enum class support

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,27 @@ my_second_literal: Literal[0, 1, 2]
 }
 ```
 
+Python's `Enum` classes are also supported:
+
+```python
+from enum import Enum
+
+class MyEnum(Enum):
+    One = "One"
+    Two = "Two"
+    Three = "Three"
+
+my_enum: MyEnum
+
+# Would convert to
+{
+    "my_enum": {
+        "type": "string",
+        "enum": ["One", "Two", "Three"]
+    }
+}
+```
+
 ### Convert a type to a JSON Schema Type
 
 The ```to_json_schema_type``` function can be used to convert a type, union, tuple of types, or list of types into a JSON Schema type:


### PR DESCRIPTION
## Summary
- support converting Enum classes to JSON schema enums
- allow JSON calls to mold Enum inputs
- document Enum class usage
- test Enum class support

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a0debc108320b97fbb37785ee1f6